### PR TITLE
fix: sample image path

### DIFF
--- a/.config/samples-config-v3.json
+++ b/.config/samples-config-v3.json
@@ -631,7 +631,7 @@
             ],
             "time": "5min to run",
             "configuration": "Manual configurations required",
-            "thumbnailPath": "Images/2.WelcomeCard.PNG",
+            "thumbnailPath": "Images/2.welcome.png",
             "gifPath": "Images/BotConversation.gif",
             "suggested": false,
             "downloadUrlInfo": {
@@ -658,7 +658,7 @@
             ],
             "time": "5min to run",
             "configuration": "Manual configurations required",
-            "thumbnailPath": "Images/4-search-Result-ME.png",
+            "thumbnailPath": "Images/5.Select_result.png",
             "gifPath": "Images/msgext-search.gif",
             "suggested": false,
             "downloadUrlInfo": {


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/29016018

Effect:
![image](https://github.com/user-attachments/assets/9e29e96c-1e18-4ae5-81b9-cc5c161689a9)
