### PR TITLE
Added a logic to omit `:`  when the port number is not present.

### DIFF
--- a/graph-connector-app/tabs/src/components/TabConfig.tsx
+++ b/graph-connector-app/tabs/src/components/TabConfig.tsx
@@ -17,7 +17,8 @@ class TabConfig extends React.Component {
        * the settings selected by the user.
        */
       pages.config.registerOnSaveHandler((saveEvent) => {
-        const baseUrl = `https://${window.location.hostname}:${window.location.port}`;
+        const port = window.location.port ? `:${window.location.port}` : '';
+        const baseUrl = `https://${window.location.hostname}${port}`;
         pages.config
           .setConfig({
             suggestedDisplayName: "My Tab",

--- a/graph-toolkit-contact-exporter/src/components/TabConfig.js
+++ b/graph-toolkit-contact-exporter/src/components/TabConfig.js
@@ -21,7 +21,8 @@ class TabConfig extends React.Component {
        * the settings selected by the user.
        */
       pages.config.registerOnSaveHandler((saveEvent) => {
-        const baseUrl = `https://${window.location.hostname}:${window.location.port}`;
+        const port = window.location.port ? `:${window.location.port}` : '';
+        const baseUrl = `https://${window.location.hostname}${port}`;
         pages.config
           .setConfig({
             suggestedDisplayName: "My Tab",


### PR DESCRIPTION
Teams regex does not support urls with domain ending with colon without a port number. 
Eg: `https://www.microsoft.com:/some_path`

This PR adds a logic to omit `:` when the port number is not present.
A lot of developers will adopt these examples and will find the samples not working on Teams Mobile. 

It is important to note that this will only work when the port number is not present.