### PR TITLE
fix: remove unuse task for test-tool-sample-app

### DIFF
--- a/test-tool-sample-app/.vscode/launch.json
+++ b/test-tool-sample-app/.vscode/launch.json
@@ -2,56 +2,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Remote (Edge)",
-            "type": "msedge",
-            "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
-            "presentation": {
-                "group": "3-remote",
-                "order": 1
-            },
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
-            "name": "Launch Remote (Chrome)",
-            "type": "chrome",
-            "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
-            "presentation": {
-                "group": "3-remote",
-                "order": 2
-            },
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
-            "name": "Launch App (Edge)",
-            "type": "msedge",
-            "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
-            "cascadeTerminateToConfigurations": [
-                "Attach to Local Service"
-            ],
-            "presentation": {
-                "group": "all",
-                "hidden": true
-            },
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
-            "name": "Launch App (Chrome)",
-            "type": "chrome",
-            "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
-            "cascadeTerminateToConfigurations": [
-                "Attach to Local Service"
-            ],
-            "presentation": {
-                "group": "all",
-                "hidden": true
-            },
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
             "name": "Attach to Local Service",
             "type": "node",
             "request": "attach",
@@ -65,32 +15,6 @@
         }
     ],
     "compounds": [
-        {
-            "name": "Debug in Teams (Edge)",
-            "configurations": [
-                "Launch App (Edge)",
-                "Attach to Local Service"
-            ],
-            "preLaunchTask": "Start Teams App Locally",
-            "presentation": {
-                "group": "2-local",
-                "order": 1
-            },
-            "stopAll": true
-        },
-        {
-            "name": "Debug in Teams (Chrome)",
-            "configurations": [
-                "Launch App (Chrome)",
-                "Attach to Local Service"
-            ],
-            "preLaunchTask": "Start Teams App Locally",
-            "presentation": {
-                "group": "2-local",
-                "order": 2
-            },
-            "stopAll": true
-        },
         {
             "name": "Debug in Test Tool (Preview)",
             "configurations": [

--- a/test-tool-sample-app/package.json
+++ b/test-tool-sample-app/package.json
@@ -10,9 +10,6 @@
     "dev:teamsfx:testtool": "env-cmd --silent -f .localConfigs.testTool npm run dev",
     "dev:teamsfx:launch-testtool": "env-cmd --silent -f ./env/.env.testtool teamsapptester start",
     "dev": "nodemon --watch ./src --exec node --inspect=9241 --signal SIGINT -r ts-node/register ./src/index.ts",
-    "build": "tsc --build && shx cp -r ./src/adaptiveCards ./lib/src",
-    "start": "node ./lib/src/index.js",
-    "watch": "nodemon --watch ./src --exec \"npm run start\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/test-tool-sample-app/package.json
+++ b/test-tool-sample-app/package.json
@@ -36,6 +36,6 @@
     "nodemon": "^3.1.7",
     "shx": "^0.3.4",
     "ts-node": "^10.4.0",
-    "typescript": "^4.4.4"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
https://github.com/OfficeDev/teams-toolkit-samples/issues/1398
test-tool-sample-app just for show the test tool so remove the tasks: "Debug in Team", "Launch Remote "
after remove above, sample still could run in test tool

https://github.com/user-attachments/assets/cbd9b247-7749-4031-88df-c87df86f600f

