### PR TITLE
feat: create cognitive service module

### DIFF
--- a/genai-gateway/infra/apim/modules/cognitiveService.bicep
+++ b/genai-gateway/infra/apim/modules/cognitiveService.bicep
@@ -1,0 +1,48 @@
+@maxLength(20)
+@minLength(4)
+@description('Used to generate names for all resources in this file')
+param resourceBaseName string
+
+param location string = resourceGroup().location
+
+param openAISku string = 'S0'
+
+param openAISkuTier string = 'Standard'
+
+resource cognitiveService 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: 'cog-${resourceBaseName}-${location}'
+  location: location
+  sku: {
+    name: openAISku
+    tier: openAISkuTier
+  }
+  kind: 'OpenAI'  
+  properties: {
+    apiProperties: {
+      statisticsEnabled: false
+    }
+    publicNetworkAccess: 'Enabled'
+    customSubDomainName: toLower('cog-${resourceBaseName}-${location}')
+  }
+}
+
+resource openaideployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01'  =  {
+  name: 'openaideploy'
+  parent: cognitiveService
+  properties: {
+    model: {
+      format: 'OpenAI'
+      name: 'gpt-35-turbo'
+      version: '0613'
+    }
+  }
+  sku: {
+      name: 'GlobalStandard'
+      capacity: 10
+  }
+}
+
+#disable-next-line outputs-should-not-contain-secrets
+output azureOpenAIApiKey string = listKeys(cognitiveService.id, '2022-10-01').key1
+#disable-next-line outputs-should-not-contain-secrets
+output azureOpenAIEndpoint string = listKeys(cognitiveService.id, '2022-10-01').endpoint


### PR DESCRIPTION
Existing error: 
```
“Cognitive-Service-deployment": {
    "code": "InvalidTemplateDeployment",
    "message": "The template deployment 'Cognitive-Service-deployment' is not valid according to the validation procedure. The tracking id is '765f2725-b6c7-4214-899e-9fb9738855d0'. See inner errors for details.",
    "details": [
      {
        "code": "SpecialFeatureOrQuotaIdRequired",
        "message": "The subscription does not have QuotaId/Feature required by SKU 'S0' from kind 'OpenAI' or contains blocked QuotaId/Feature."
      }
    ]
  }
```
Related Known issue: https://learn.microsoft.com/en-us/answers/questions/1413436/how-to-fix-azure-openai-error-the-subscription-doe
```
Azure account permissions:
Your Azure account must have Microsoft.Authorization/roleAssignments/write permissions, such as [Role Based Access Control Administrator](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#role-based-access-control-administrator-preview), [User Access Administrator](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#user-access-administrator), or [Owner](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#owner). If you don't have subscription-level permissions, you must be granted [RBAC](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#role-based-access-control-administrator-preview) for an existing resource group and [deploy to that existing group](https://github.com/Azure-Samples/azure-search-openai-demo#existing-resource-group).
Your Azure account also needs Microsoft.Resources/deployments/write permissions on the subscription level.
```
